### PR TITLE
add to confirm that it loads headers from the response schema

### DIFF
--- a/src/Objects/Response.php
+++ b/src/Objects/Response.php
@@ -27,6 +27,7 @@ class Response
             $this->content[$mediaType] = new MediaType($mediaType, $mediaTypeArgs);
         }
         $this->required = $args['required'] ?? false;
+        $this->headers = $args['headers'] ?? null;
     }
 
     public function getContent($mediaType = null) : ?MediaType

--- a/tests/OpenApiReaderTest.php
+++ b/tests/OpenApiReaderTest.php
@@ -78,4 +78,11 @@ class OpenApiReaderTest extends TestCase
         $codes   = $openapi->getOperationResponseCodes('/things', 'get');
         $this->assertSame([200, 'default'], $codes);
     }
+
+    public function testGetOperationResponseHeaders()
+    {
+        $openapi = new OpenApiReader(__DIR__.'/testopenapi.json');
+        $response   = $openapi->getOperationResponse('/all/', 'get', 200);
+        $this->assertArrayHasKey('x-next', $response->headers);
+    }
 }

--- a/tests/OpenApiReaderTest.php
+++ b/tests/OpenApiReaderTest.php
@@ -84,5 +84,6 @@ class OpenApiReaderTest extends TestCase
         $openapi = new OpenApiReader(__DIR__.'/testopenapi.json');
         $response   = $openapi->getOperationResponse('/all/', 'get', 200);
         $this->assertArrayHasKey('x-next', $response->headers);
+        $this->assertArrayHasKey('x-response-id', $response->headers);
     }
 }

--- a/tests/testopenapi.json
+++ b/tests/testopenapi.json
@@ -29,6 +29,9 @@
                   "schema": {
                     "type": "string"
                   }
+                },
+                "x-response-id": {
+                  "$ref": "#/components/headers/xResponseId"
                 }
               },
               "content": {
@@ -191,6 +194,16 @@
       }
     },
     "components": {
+      "headers": {
+        "xResponseId": {
+          "required":true,
+          "schema": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "description": "Unique response ID"
+        }
+      },
       "schemas": {
         "Thing": {
           "required": [


### PR DESCRIPTION
This PR tests that Reader loads headers defined in the `/paths/{path}/{method}/responses/{code}/headers` section.