### PR TITLE
Add static constructor for readers

### DIFF
--- a/src/AbstractReader.php
+++ b/src/AbstractReader.php
@@ -13,7 +13,26 @@ namespace HKarlstrom\OpenApiReader;
 
 abstract class AbstractReader
 {
+    /**
+     * @throws \Exception If the OpenAPI file is not a supported type.
+     */
+    public static function fromFile(string $openApiFilePath): AbstractReader
+    {
+        if (preg_match('/\.json$/', $openApiFilePath) === 1) {
+            return new JsonReader($openApiFilePath);
+        }
+
+        if (preg_match('/\.ya?ml$/', $openApiFilePath) === 1) {
+            return new YamlReader($openApiFilePath);
+        }
+
+        throw new \Exception('OpenAPI file name must have .json, .yaml or .yml extension');
+    }
+
+    /** @var array */
     protected $raw;
+
+    /** @var array */
     protected $cache;
 
     public function get($path)

--- a/src/OpenApiReader.php
+++ b/src/OpenApiReader.php
@@ -15,6 +15,7 @@ use Rize\UriTemplate;
 
 class OpenApiReader
 {
+    /** @var string[] */
     private static $methods = [
         'get',
         'put',
@@ -25,27 +26,13 @@ class OpenApiReader
         'patch',
         'trace',
     ];
+
+    /** @var AbstractReader */
     private $reader;
 
-    /**
-     * OpenApiReader constructor.
-     *
-     * @param string $openApiFilePath
-     *
-     * @throws \Exception
-     */
     public function __construct(string $openApiFilePath)
     {
-        if (preg_match('/\.json$/', $openApiFilePath) === 1) {
-            $this->reader = new JsonReader($openApiFilePath);
-            return;
-        }
-        if (preg_match('/\.ya?ml$/', $openApiFilePath) === 1) {
-            $this->reader = new YamlReader($openApiFilePath);
-            return;
-        }
-
-        throw new \Exception('OpenAPI file name must have .json, .yaml or .yml extension');
+        $this->reader = AbstractReader::fromFile($openApiFilePath);
     }
 
     public function getVersion() : string

--- a/tests/AbstractReaderFromFileTest.php
+++ b/tests/AbstractReaderFromFileTest.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace HKarlstrom\OpenApiReader\Tests;
+
+use HKarlstrom\OpenApiReader\AbstractReader;
+use HKarlstrom\OpenApiReader\JsonReader;
+use HKarlstrom\OpenApiReader\YamlReader;
+use PHPUnit\Framework\TestCase;
+
+class AbstractReaderFromFileTest extends TestCase
+{
+    public function testCreateFromJson(): void
+    {
+        $reader = AbstractReader::fromFile(__DIR__ . '/testopenapi.json');
+
+        $this->assertInstanceOf(JsonReader::class, $reader);
+    }
+
+    public function testCreateFromYaml(): void
+    {
+        $reader = AbstractReader::fromFile(__DIR__ . '/testopenapi.yaml');
+
+        $this->assertInstanceOf(YamlReader::class, $reader);
+    }
+}


### PR DESCRIPTION
Allows creating readers without manually detecting file.