### PR TITLE
MediaType::getExample: fix nullable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .DS_Store
 /.idea
 /.phpunit.result.cache
+Changelog.md
+*.sh

--- a/src/Objects/MediaType.php
+++ b/src/Objects/MediaType.php
@@ -2,9 +2,7 @@
 
 /**
  * OpenAPI Reader.
- *
  * @see       https://github.com/hkarlstrom/openapi-reader
- *
  * @copyright Copyright (c) 2018 Henrik Karlström
  * @license   MIT
  */
@@ -13,25 +11,54 @@ namespace HKarlstrom\OpenApiReader\Objects;
 
 class MediaType
 {
+    /**
+     * @var string
+     */
     public $type;
+
+    /**
+     * @var mixed|null
+     */
     public $schema;
+
+    /**
+     * @var mixed|null
+     */
     public $example;
+
+    /**
+     * @var array|mixed|null
+     */
     public $examples = [];
+
+    /**
+     * @var array
+     */
     public $encoding = [];
 
+    /**
+     * @param string $type
+     * @param array  $args
+     */
     public function __construct(string $type, array $args)
     {
-        $this->type     = $type;
-        $this->schema   = $args['schema']   ?? null;
-        $this->example  = $args['example']  ?? null;
-        $this->examples = $args['examples'] ?? null;
-        foreach ($args['encoding'] ?? [] as $property => $encodingArgs) {
+        $this->type = $type;
+        $this->schema = ($args['schema'] ?? null);
+        $this->example = ($args['example'] ?? null);
+        $this->examples = ($args['examples'] ?? null);
+
+        foreach (($args['encoding'] ?? []) as $property => $encodingArgs)
+        {
             $this->encoding[$property] = new Encoding($property, $encodingArgs);
         }
     }
 
-    public function getExample(string $type = null) : ?array
+    /**
+     * @param string|null $type
+     * @return array|null
+     */
+    public function getExample(?string $type = null): ?array
     {
-        return $this->examples[$type] ?? $this->example;
+        return ($this->examples[$type] ?? $this->example);
     }
 }


### PR DESCRIPTION
**fixed**

- `\HKarlstrom\OpenApiReader\Objects\MediaType::getExample`: Implicitly marking parameter as nullable is deprecated